### PR TITLE
Updating manifest to allow tablets

### DIFF
--- a/extras.manifest.txt
+++ b/extras.manifest.txt
@@ -6,3 +6,4 @@
 
 <permission android:protectionLevel="signature" android:name="plugin.fortumo.PAYMENT_BROADCAST_PERMISSION" />
 <uses-permission android:name="plugin.fortumo.PAYMENT_BROADCAST_PERMISSION" />
+<uses-feature android:name="android.hardware.telephony" android:required="false" />


### PR DESCRIPTION
This extension is causing my app to get excluded for tablets. Fixing this issue by telling Android that telephony is not required: http://developer.android.com/guide/topics/manifest/uses-feature-element.html#permissions.
